### PR TITLE
disable the default enabled cookie feature for leptos_i18n

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,8 +1103,6 @@ dependencies = [
  "leptos_axum",
  "leptos_i18n_macro",
  "leptos_meta",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ wasm-bindgen = "0.2.84"
 thiserror = "1.0.40"
 tracing = { version = "0.1.37", optional = true }
 http = "0.2.9"
-leptos_i18n = "0.2.3"
+leptos_i18n = { version = "0.2.3", default_features = false, features = ["json_files"] }
 leptos_icons = { version = "0.1.0", default_features = false, features = ["FaGithubBrands", "FaLinkedinBrands", "FaXingBrands", "FiExternalLink"] }
 
 [features]


### PR DESCRIPTION
In the EU the usage of cookies would require me to setup a cookie banner. I want to avoid that at all costs, so I do not store the last user selected language preference in a cookie anymore.